### PR TITLE
Don't throw IndexOutOfRangeException

### DIFF
--- a/EasyConfig.Net.Core/Config.cs
+++ b/EasyConfig.Net.Core/Config.cs
@@ -75,6 +75,11 @@ namespace EasyConfig
 
             foreach (var pair in split)
             {
+                if (pair.Length != 2)
+                {
+                    continue;
+                }
+
                 argsDict[pair[0]] = pair[1];
             }
 

--- a/EasyConfig.UnitTests/ConfigTests.cs
+++ b/EasyConfig.UnitTests/ConfigTests.cs
@@ -103,6 +103,12 @@ namespace EasyConfig.UnitTests
         }
 
         [Test]
+        public void Populate_IntRequired_ExtraParameters_DoesNotThrow()
+        {
+            Assert.DoesNotThrow(() => Config.Populate<IntRequired>("number=1", "unexpected-positional-argument"));
+        }
+
+        [Test]
         public void Populate_IntRequired_SetsNumber()
         {
             var num = new Random().Next();


### PR DESCRIPTION
Moving from positional to named arguments for NuKeeper, I got an IndexOutOfRangeException, as the parsing failed. This changes the behaviour to ignore unnamed arguments instead of crashing.